### PR TITLE
updated main to point to the actual library

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "angular-ui-notification",
   "version": "0.0.5",
   "description": "Angular.js service providing simple notifications using Bootstrap 3 styles with css transitions for animating",
-  "main": "index.js",
+  "main": "dist/angular-ui-notification.min",
   "scripts": {
     "update-chromedriver": "./node_modules/protractor/bin/webdriver-manager update",
     "test": "gulp tests"


### PR DESCRIPTION
It was pointing to index.js which is the default - but tools like jspm can't install this library properly without a valid main.

this was tested by using the jspm install -o flag and manually specifying this entry point.
